### PR TITLE
Add autosecure to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@
 - [**CIRCL**](https://www.circl.lu/services) – Computer Incident Response Center Luxembourg; provides threat intelligence feeds and malware analysis.  
 - [**Hybrid Analysis**](https://www.hybrid-analysis.com) – Malware analysis service with detailed threat intelligence reports.  
 - [**Abuse.ch**](https://abuse.ch) – Provides threat feeds such as ransomware and malware campaign trackers.  
+- [**autosecure**](https://github.com/vincentkoc/autosecure) - Threat-feed IP block automation for Linux and macOS firewalls.
 
 ---
 


### PR DESCRIPTION
Adds [autosecure](https://github.com/vincentkoc/autosecure), a threat-feed IP block automation tool for Linux and macOS firewalls (iptables, nftables, pf).